### PR TITLE
Add country rankings by EPI score and country deep dive page

### DIFF
--- a/country-power-tracker/app/components/EpiRankings.tsx
+++ b/country-power-tracker/app/components/EpiRankings.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Country = {
+  iso3: string;
+  name: string;
+  green_score: number | null;
+  region: string;
+  data_year: number;
+};
+
+type Props = {
+  countries: Country[];
+};
+
+export default function EpiRankings({ countries }: Props) {
+  const router = useRouter();
+  const [search, setSearch] = useState("");
+
+  const ranked = [...countries]
+    .filter((c) => c.green_score !== null)
+    .sort((a, b) => (b.green_score ?? 0) - (a.green_score ?? 0));
+
+  const filtered = search
+    ? ranked.filter((c) =>
+        c.name.toLowerCase().includes(search.toLowerCase())
+      )
+    : ranked;
+
+  const getScoreColor = (score: number) => {
+    if (score >= 60) return "text-green-400";
+    if (score >= 40) return "text-yellow-400";
+    return "text-red-400";
+  };
+
+  const getBarColor = (score: number) => {
+    if (score >= 60) return "bg-green-500";
+    if (score >= 40) return "bg-yellow-500";
+    return "bg-red-500";
+  };
+
+  return (
+    <div className="w-80 bg-gray-900 rounded-xl border border-gray-800 flex flex-col max-h-[600px]">
+      <div className="p-4 border-b border-gray-800">
+        <h2 className="text-white text-lg font-bold mb-3">
+          Country Rankings
+        </h2>
+        <input
+          type="text"
+          placeholder="Search countries..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full px-3 py-2 bg-gray-800 text-white text-sm rounded-lg border border-gray-700 focus:border-blue-500 focus:outline-none placeholder-gray-500"
+        />
+      </div>
+      <div className="overflow-y-auto flex-1 p-2">
+        {filtered.map((country, i) => {
+          const rank = ranked.indexOf(country) + 1;
+          return (
+            <button
+              key={country.iso3}
+              onClick={() => router.push(`/country/${country.iso3}`)}
+              className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors text-left"
+            >
+              <span className="text-gray-500 text-sm font-mono w-6 text-right shrink-0">
+                {rank}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-white text-sm truncate">
+                  {country.name}
+                </div>
+                <div className="w-full bg-gray-800 rounded-full h-1.5 mt-1">
+                  <div
+                    className={`h-1.5 rounded-full ${getBarColor(country.green_score!)}`}
+                    style={{ width: `${country.green_score}%` }}
+                  />
+                </div>
+              </div>
+              <span
+                className={`text-sm font-bold shrink-0 ${getScoreColor(country.green_score!)}`}
+              >
+                {country.green_score!.toFixed(1)}
+              </span>
+            </button>
+          );
+        })}
+        {filtered.length === 0 && (
+          <p className="text-gray-500 text-sm text-center py-4">
+            No countries found
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/country-power-tracker/app/components/WorldGlobe.tsx
+++ b/country-power-tracker/app/components/WorldGlobe.tsx
@@ -21,7 +21,7 @@ const NUMERIC_TO_ISO3: Record<number, string> = {
 import { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
 import { feature } from "topojson-client";
-//import { useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 type Country = {
   iso3: string;
@@ -37,7 +37,7 @@ type Props = {
 
 export default function WorldGlobe({ countries }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  //const router = useRouter();
+  const router = useRouter();
   const [tooltip, setTooltip] = useState<{ x: number; y: number; name: string; score: number } | null>(null);
 
   useEffect(() => {
@@ -113,9 +113,12 @@ export default function WorldGlobe({ countries }: Props) {
             d3.select(this).attr("stroke-width", 0.3).attr("stroke", "#ffffff");
             setTooltip(null);
         })
-        //.on("click", (event: MouseEvent, d: any) => {
-          // Will route to country card once iso3 mapping is added
-        //});
+        .on("click", (_event: MouseEvent, d: any) => {
+            const iso3 = NUMERIC_TO_ISO3[+d.id];
+            if (iso3) {
+              router.push(`/country/${iso3}`);
+            }
+        });
 
       // Graticule
       const graticule = d3.geoGraticule();
@@ -157,7 +160,7 @@ export default function WorldGlobe({ countries }: Props) {
 
       svg.call(zoom);
     });
-  }, [countries]);
+  }, [countries, router]);
 
   return (
     <div className="relative flex items-center justify-center">

--- a/country-power-tracker/app/country/[iso3]/CountryDeepDive.tsx
+++ b/country-power-tracker/app/country/[iso3]/CountryDeepDive.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+type SeriesPoint = {
+  year: number;
+  co2_per_capita: number;
+  co2_per_gdp: number;
+};
+
+type Props = {
+  iso3: string;
+  name: string;
+  greenScore: number | null;
+  region: string;
+  series: SeriesPoint[];
+};
+
+export default function CountryDeepDive({
+  name,
+  greenScore,
+  region,
+  series,
+}: Props) {
+  const router = useRouter();
+
+  const getScoreColor = (score: number) => {
+    if (score >= 60) return "text-green-400";
+    if (score >= 40) return "text-yellow-400";
+    return "text-red-400";
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-950 text-white p-8">
+      <button
+        onClick={() => router.push("/")}
+        className="mb-6 flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+      >
+        <span>&larr;</span> Back to Globe
+      </button>
+
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">{name}</h1>
+          <div className="flex items-center gap-4 text-sm">
+            <span className="text-gray-400">{region}</span>
+            {greenScore !== null && (
+              <span
+                className={`font-bold text-lg ${getScoreColor(greenScore)}`}
+              >
+                EPI Score: {greenScore.toFixed(1)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Chart */}
+        {series.length > 0 ? (
+          <div className="bg-gray-900 rounded-xl border border-gray-800 p-6">
+            <h2 className="text-lg font-semibold mb-4">
+              CO2 Emissions Over Time
+            </h2>
+            <ResponsiveContainer width="100%" height={400}>
+              <LineChart data={series}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                <XAxis
+                  dataKey="year"
+                  stroke="#9CA3AF"
+                  tick={{ fontSize: 12 }}
+                />
+                <YAxis
+                  yAxisId="left"
+                  stroke="#60A5FA"
+                  tick={{ fontSize: 12 }}
+                  label={{
+                    value: "CO2 per Capita (t)",
+                    angle: -90,
+                    position: "insideLeft",
+                    style: { fill: "#60A5FA", fontSize: 12 },
+                  }}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="#F472B6"
+                  tick={{ fontSize: 12 }}
+                  label={{
+                    value: "CO2 per GDP (kg/$)",
+                    angle: 90,
+                    position: "insideRight",
+                    style: { fill: "#F472B6", fontSize: 12 },
+                  }}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "#1F2937",
+                    border: "1px solid #374151",
+                    borderRadius: "8px",
+                    color: "#fff",
+                  }}
+                  labelStyle={{ color: "#9CA3AF" }}
+                />
+                <Legend />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="co2_per_capita"
+                  name="CO2 per Capita (tonnes)"
+                  stroke="#60A5FA"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="co2_per_gdp"
+                  name="CO2 per GDP (kg/$)"
+                  stroke="#F472B6"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <div className="bg-gray-900 rounded-xl border border-gray-800 p-12 text-center">
+            <p className="text-gray-500 text-lg">
+              No emissions data available for this country.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/country-power-tracker/app/country/[iso3]/page.tsx
+++ b/country-power-tracker/app/country/[iso3]/page.tsx
@@ -1,0 +1,47 @@
+import CountryDeepDive from "./CountryDeepDive";
+import countriesData from "../../../public/data/countries.json";
+import deepDiveData from "../../../public/data/country_deep_dive.json";
+
+type DeepDiveEntry = {
+  iso3: string;
+  series: { year: number; co2_per_capita: number; co2_per_gdp: number }[];
+};
+
+type CountryEntry = {
+  iso3: string;
+  name: string;
+  green_score: number | null;
+  region: string;
+  data_year: number;
+};
+
+type Props = {
+  params: Promise<{ iso3: string }>;
+};
+
+export default async function CountryPage({ params }: Props) {
+  const { iso3 } = await params;
+  const upper = iso3.toUpperCase();
+
+  const country = (countriesData as CountryEntry[]).find(
+    (c) => c.iso3 === upper
+  );
+  const deepDive = (deepDiveData as DeepDiveEntry[]).find(
+    (d) => d.iso3 === upper
+  );
+
+  const name = country?.name ?? upper;
+  const greenScore = country?.green_score ?? null;
+  const region = country?.region ?? "Unknown";
+  const series = deepDive?.series ?? [];
+
+  return (
+    <CountryDeepDive
+      iso3={upper}
+      name={name}
+      greenScore={greenScore}
+      region={region}
+      series={series}
+    />
+  );
+}

--- a/country-power-tracker/app/page.tsx
+++ b/country-power-tracker/app/page.tsx
@@ -1,13 +1,17 @@
 import WorldGlobe from "./components/WorldGlobe";
 import Recommendations from "./components/Recommendations";
+import EpiRankings from "./components/EpiRankings";
 import countries from "../public/data/countries.json";
 import recommendations from "../public/data/recommendations.json";
 
 export default function Home() {
   return (
     <main className="min-h-screen bg-gray-950 flex flex-col items-center py-12">
-      <h1 className="text-white text-3xl font-bold mb-8">🌍 Country Power Tracker</h1>
-      <WorldGlobe countries={countries} />
+      <h1 className="text-white text-3xl font-bold mb-8">Country Power Tracker</h1>
+      <div className="flex flex-col lg:flex-row items-start justify-center gap-8">
+        <WorldGlobe countries={countries} />
+        <EpiRankings countries={countries} />
+      </div>
       <Recommendations data={recommendations} />
     </main>
   );


### PR DESCRIPTION
- Add EpiRankings sidebar on main page showing all countries ranked by green_score with search, color-coded scores, and click-to-navigate
- Enable globe click handler to navigate to /country/[iso3] deep dive
- Create country deep dive page with dual-axis Recharts line chart showing CO2 per capita and CO2 per GDP over time
- Update main page layout to display globe and rankings side-by-side

https://claude.ai/code/session_01QMRRxiQEJQCtrzu4ycdik9